### PR TITLE
Optimize reading responses

### DIFF
--- a/client.go
+++ b/client.go
@@ -5,6 +5,7 @@
 package cloudcraft
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -218,14 +219,15 @@ func (c *Client) do(ctx context.Context, req *http.Request) (*Response, error) {
 		return nil, fmt.Errorf("%w: %d", ErrRequestFailed, resp.StatusCode)
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	var buffer bytes.Buffer
+	_, err = io.Copy(&buffer, resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("%w", err)
 	}
 
 	return &Response{
 		Header: resp.Header,
-		Body:   body,
+		Body:   buffer.Bytes(),
 		Status: resp.StatusCode,
 	}, nil
 }

--- a/client.go
+++ b/client.go
@@ -220,6 +220,7 @@ func (c *Client) do(ctx context.Context, req *http.Request) (*Response, error) {
 	}
 
 	var buffer bytes.Buffer
+
 	_, err = io.Copy(&buffer, resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("%w", err)

--- a/client.go
+++ b/client.go
@@ -219,9 +219,15 @@ func (c *Client) do(ctx context.Context, req *http.Request) (*Response, error) {
 		return nil, fmt.Errorf("%w: %d", ErrRequestFailed, resp.StatusCode)
 	}
 
-	var buffer bytes.Buffer
+	var buffer *bytes.Buffer
 
-	_, err = io.Copy(&buffer, resp.Body)
+	if resp.ContentLength > 0 {
+		buffer = bytes.NewBuffer(make([]byte, 0, resp.ContentLength))
+	} else {
+		buffer = bytes.NewBuffer(make([]byte, 0))
+	}
+
+	_, err = io.Copy(buffer, resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("%w", err)
 	}


### PR DESCRIPTION
### What does this PR do?
Replaces `io.ReadAll` with `io.Copy` and a preallocated buffer, which decreases the number of allocations and usage happening in this portion of the code by up to 50%.

This is a big win for extremelly large diagrams, while causing no issues with small diagrams.

### Review checklist

Please check relevant items below:

- [x] The title & description contain a short meaningful summary of work completed.
- [x] Tests have been updated/created and are passing locally.
- [x] I've reviewed the [CONTRIBUTING.md](/CONTRIBUTING.md) file.
