### PR TITLE
Retry failed HTTP requests

### DIFF
--- a/client.go
+++ b/client.go
@@ -42,6 +42,9 @@ type (
 		// httpClient is the underlying HTTP client used by the API client.
 		httpClient *http.Client
 
+		// retryPolicy specifies the policy used to retry failed requests.
+		retryPolicy *xhttp.RetryPolicy
+
 		// cfg specifies the configuration used by the API client.
 		cfg *Config
 
@@ -74,13 +77,23 @@ func NewClient(cfg *Config) (*Client, error) {
 
 	cfg.endpoint = baseURL
 
+	if cfg.MaxRetries <= 0 {
+		cfg.MaxRetries = DefaultMaxRetries
+	}
+
 	if cfg.Timeout <= 0 {
 		cfg.Timeout = DefaultTimeout
 	}
 
 	client := &Client{
 		httpClient: xhttp.NewClient(cfg.Timeout),
-		cfg:        cfg,
+		retryPolicy: &xhttp.RetryPolicy{
+			IsRetryable:   xhttp.DefaultIsRetryable,
+			MaxRetries:    cfg.MaxRetries,
+			MinRetryDelay: xhttp.DefaultMinRetryDelay,
+			MaxRetryDelay: xhttp.DefaultMaxRetryDelay,
+		},
+		cfg: cfg,
 	}
 
 	client.common.client = client

--- a/client.go
+++ b/client.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -220,8 +219,6 @@ func (c *Client) do(req *http.Request) (*Response, error) {
 	}
 
 	for attempt := 0; attempt <= c.retryPolicy.MaxRetries; attempt++ {
-		log.Printf("attempt %d", attempt)
-
 		if body != nil {
 			req.Body = io.NopCloser(bytes.NewReader(body.Bytes()))
 		}

--- a/client.go
+++ b/client.go
@@ -200,7 +200,7 @@ type Response struct {
 }
 
 // do performs an HTTP request using the underlying HTTP client.
-func (c *Client) do(req *http.Request) (*Response, error) {
+func (c *Client) do(req *http.Request) (*Response, error) { //nolint:gocyclo // Necessary complexity.
 	var (
 		attempt int
 		resp    *http.Response

--- a/client_internal_test.go
+++ b/client_internal_test.go
@@ -177,20 +177,6 @@ func TestDo(t *testing.T) {
 			context: ctx,
 			wantErr: true,
 		},
-		{
-			name: "Rate Limiter Error",
-			handler: func(w http.ResponseWriter, _ *http.Request) {
-				w.WriteHeader(http.StatusOK)
-			},
-			context: func() context.Context {
-				ctxWithCancel, cancel := context.WithCancel(ctx)
-
-				cancel()
-
-				return ctxWithCancel
-			}(),
-			wantErr: true,
-		},
 	}
 
 	for _, tt := range tests {

--- a/client_internal_test.go
+++ b/client_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"reflect"
 	"strconv"
+	"sync"
 	"testing"
 	"time"
 )
@@ -292,6 +293,158 @@ func TestRequest(t *testing.T) {
 
 			if got.URL.String() != tt.want.URL.String() {
 				t.Fatalf("Request().URL = %v, want %v", got.URL, tt.want.URL)
+			}
+		})
+	}
+}
+
+func TestDo_Retries_GET(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		giveResponses      []int
+		giveRetries        int
+		giveDelay          time.Duration
+		giveTimeoutContext time.Duration
+		wantAttempts       int
+		wantFinalResponse  int
+		wantErr            bool
+	}{
+		{
+			name: "Success on first attempt",
+			giveResponses: []int{
+				http.StatusOK,
+			},
+			giveRetries:        3,
+			giveDelay:          0,
+			giveTimeoutContext: 5 * time.Second,
+			wantAttempts:       1,
+			wantFinalResponse:  http.StatusOK,
+			wantErr:            false,
+		},
+		{
+			name: "Success on third attempt",
+			giveResponses: []int{
+				http.StatusInternalServerError,
+				http.StatusBadGateway,
+				http.StatusOK,
+			},
+			giveRetries:        3,
+			giveDelay:          0,
+			giveTimeoutContext: 5 * time.Second,
+			wantAttempts:       3,
+			wantFinalResponse:  http.StatusOK,
+			wantErr:            false,
+		},
+		{
+			name: "Failure by exceeding max retries",
+			giveResponses: []int{
+				http.StatusInternalServerError,
+				http.StatusBadGateway,
+				http.StatusServiceUnavailable,
+				http.StatusGatewayTimeout,
+			},
+			giveRetries:        2,
+			giveDelay:          0,
+			giveTimeoutContext: 5 * time.Second,
+			wantAttempts:       3,
+			wantFinalResponse:  http.StatusServiceUnavailable,
+			wantErr:            true,
+		},
+		{
+			name: "Failure by context cancellation",
+			giveResponses: []int{
+				http.StatusInternalServerError,
+				http.StatusBadGateway,
+				http.StatusServiceUnavailable,
+				http.StatusGatewayTimeout,
+			},
+			giveRetries:        3,
+			giveDelay:          2 * time.Second,
+			giveTimeoutContext: 1 * time.Second,
+			wantAttempts:       0,
+			wantFinalResponse:  http.StatusInternalServerError,
+			wantErr:            true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var (
+				mu       sync.Mutex
+				requests int
+				srv      = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					time.Sleep(tt.giveDelay)
+
+					respIndex := requests
+
+					if respIndex >= len(tt.giveResponses) {
+						respIndex = len(tt.giveResponses) - 1
+					}
+
+					w.WriteHeader(tt.giveResponses[respIndex])
+
+					mu.Lock()
+					requests++
+					mu.Unlock()
+				}))
+			)
+
+			defer srv.Close()
+
+			endpoint, err := url.Parse(srv.URL)
+			if err != nil {
+				t.Fatalf("failed to parse mock server URL: %v", err)
+			}
+
+			cfg := &Config{
+				Scheme:     endpoint.Scheme,
+				Host:       endpoint.Hostname(),
+				Port:       endpoint.Port(),
+				Path:       DefaultPath,
+				MaxRetries: tt.giveRetries,
+				Key:        "not-a-real-key-oRbwhd5RTvWsPJ89ZkASHU13qcyd=",
+			}
+
+			client, err := NewClient(cfg)
+			if err != nil {
+				t.Fatalf("failed to create client for mock tests: %v", err)
+			}
+
+			client.retryPolicy.MinRetryDelay = 1 * time.Millisecond
+			client.retryPolicy.MaxRetryDelay = 1 * time.Millisecond
+			client.retryPolicy.IsRetryable = func(resp *http.Response, _ error) bool {
+				return resp.StatusCode >= 500
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), tt.giveTimeoutContext)
+			defer cancel()
+
+			req, err := client.request(ctx, http.MethodGet, endpoint.String(), http.NoBody)
+			if err != nil {
+				t.Fatalf("failed to create mock request: %v", err)
+			}
+
+			got, err := client.do(req)
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("Do() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if err == nil && got.Status != tt.wantFinalResponse {
+				t.Fatalf("unexpected final response status: got %d, want %d", got.Status, tt.wantFinalResponse)
+			}
+
+			mu.Lock()
+			gotRequests := requests
+			mu.Unlock()
+
+			if gotRequests != tt.wantAttempts {
+				t.Fatalf("unexpected number of attempts: got %d, want %d", gotRequests, tt.wantAttempts)
 			}
 		})
 	}

--- a/config.go
+++ b/config.go
@@ -45,6 +45,10 @@ const (
 	// DefaultPath is the default path to the Cloudcraft API.
 	DefaultPath string = "/"
 
+	// DefaultMaxRetries is the default maximum number of times the client will
+	// retry a request if it fails.
+	DefaultMaxRetries int = 3
+
 	// DefaultTimeout is the default timeout for requests made by the Cloudcraft
 	// API client.
 	DefaultTimeout time.Duration = time.Second * 120
@@ -52,12 +56,13 @@ const (
 
 // Environment variables used to configure the Config struct.
 const (
-	EnvScheme  string = "CLOUDCRAFT_PROTOCOL"
-	EnvHost    string = "CLOUDCRAFT_HOST"
-	EnvPort    string = "CLOUDCRAFT_PORT"
-	EnvPath    string = "CLOUDCRAFT_PATH"
-	EnvTimeout string = "CLOUDCRAFT_TIMEOUT"
-	EnvAPIKey  string = "CLOUDCRAFT_API_KEY" //nolint:gosec // false positive
+	EnvScheme     string = "CLOUDCRAFT_PROTOCOL"
+	EnvHost       string = "CLOUDCRAFT_HOST"
+	EnvPort       string = "CLOUDCRAFT_PORT"
+	EnvPath       string = "CLOUDCRAFT_PATH"
+	EnvMaxRetries string = "CLOUDCRAFT_MAX_RETRIES"
+	EnvTimeout    string = "CLOUDCRAFT_TIMEOUT"
+	EnvAPIKey     string = "CLOUDCRAFT_API_KEY" //nolint:gosec // false positive
 )
 
 // Config holds the basic configuration for the Cloudcraft API.
@@ -108,6 +113,15 @@ type Config struct {
 	// [Learn more]: https://developers.cloudcraft.co/#authentication
 	Key string
 
+	// MaxRetries is the maximum number of times the client will retry a request
+	// if it fails.
+	//
+	// If not set, the value of the CLOUDCRAFT_MAX_RETRIES environment variable
+	// is used. If the environment variable is not set, the default value is 3.
+	//
+	// This field is optional.
+	MaxRetries int
+
 	// Timeout is the time limit for requests made by the Cloudcraft API client
 	// to the Cloudcraft API.
 	//
@@ -122,24 +136,26 @@ type Config struct {
 // NewConfig returns a new Config with the given API key.
 func NewConfig(key string) *Config {
 	return &Config{
-		Scheme:  DefaultScheme,
-		Host:    DefaultHost,
-		Port:    DefaultPort,
-		Path:    DefaultPath,
-		Key:     key,
-		Timeout: DefaultTimeout,
+		Scheme:     DefaultScheme,
+		Host:       DefaultHost,
+		Port:       DefaultPort,
+		Path:       DefaultPath,
+		MaxRetries: DefaultMaxRetries,
+		Key:        key,
+		Timeout:    DefaultTimeout,
 	}
 }
 
 // NewConfigFromEnv returns a new Config from values set in the environment.
 func NewConfigFromEnv() *Config {
 	return &Config{
-		Scheme:  xos.GetEnv(EnvScheme, DefaultScheme),
-		Host:    xos.GetEnv(EnvHost, DefaultHost),
-		Port:    xos.GetEnv(EnvPort, DefaultPort),
-		Path:    xos.GetEnv(EnvPath, DefaultPath),
-		Key:     xos.GetEnv(EnvAPIKey, ""),
-		Timeout: xos.GetDurationEnv(EnvTimeout, DefaultTimeout),
+		Scheme:     xos.GetEnv(EnvScheme, DefaultScheme),
+		Host:       xos.GetEnv(EnvHost, DefaultHost),
+		Port:       xos.GetEnv(EnvPort, DefaultPort),
+		Path:       xos.GetEnv(EnvPath, DefaultPath),
+		MaxRetries: xos.GetIntEnv(EnvMaxRetries, DefaultMaxRetries),
+		Key:        xos.GetEnv(EnvAPIKey, ""),
+		Timeout:    xos.GetDurationEnv(EnvTimeout, DefaultTimeout),
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/DataDog/cloudcraft-go
 
 go 1.21
-
-require golang.org/x/time v0.5.0

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,0 @@
-golang.org/x/time v0.3.0 h1:rg5rLMjNzMS1RkNLzCG38eapWhnYLFYXDXj2gOlr8j4=
-golang.org/x/time v0.3.0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
-golang.org/x/time v0.5.0 h1:o7cqy6amK/52YcAKIPlM3a+Fpj35zvRj2TP+e1xFSfk=
-golang.org/x/time v0.5.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=

--- a/internal/xhttp/retry.go
+++ b/internal/xhttp/retry.go
@@ -15,10 +15,6 @@ const (
 )
 
 const (
-	// DefaultMaxRetries is the default maximum number of times a request will
-	// be retried.
-	DefaultMaxRetries int = 3
-
 	// DefaultMinRetryDelay is the default minimum duration to wait before
 	// retrying a request.
 	DefaultMinRetryDelay time.Duration = 1 * time.Second

--- a/internal/xhttp/retry.go
+++ b/internal/xhttp/retry.go
@@ -1,0 +1,98 @@
+package xhttp
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand"
+	"net/http"
+	"time"
+)
+
+const (
+	_backoffFactor float64 = 2.0
+	_jitterFactor  float64 = 0.1
+)
+
+const (
+	// DefaultMaxRetries is the default maximum number of times a request will
+	// be retried.
+	DefaultMaxRetries int = 3
+
+	// DefaultMinRetryDelay is the default minimum duration to wait before
+	// retrying a request.
+	DefaultMinRetryDelay time.Duration = 1 * time.Second
+
+	// DefaultMaxRetryDelay is the default maximum duration to wait before
+	// retrying a request.
+	DefaultMaxRetryDelay time.Duration = 30 * time.Second
+)
+
+// RetryPolicy defines a policy for retrying HTTP requests.
+type RetryPolicy struct {
+	// IsRetryable determines whether a given response and error combination
+	// should be retried.
+	IsRetryable func(*http.Response, error) bool
+
+	// MaxRetries is the maximum number of times a request will be retried.
+	MaxRetries int
+
+	// MinRetryDelay is the minimum duration to wait before retrying a request.
+	MinRetryDelay time.Duration
+
+	// MaxRetryDelay is the maximum duration to wait before retrying a request.
+	MaxRetryDelay time.Duration
+}
+
+// Wait calculates the time to wait before the next retry attempt and blocks
+// until it is time to retry the request or the context is canceled. It
+// incorporates an exponential backoff strategy with jitter to prevent the
+// "thundering herd" problem.
+//
+// If the context is canceled before the wait is over, Wait returns the
+// context's error.
+func (p *RetryPolicy) Wait(ctx context.Context, attempt int) error {
+	waitTime := float64(p.MinRetryDelay) * math.Pow(_backoffFactor, float64(attempt))
+
+	if time.Duration(waitTime) > p.MaxRetryDelay {
+		waitTime = float64(p.MaxRetryDelay)
+	}
+
+	jitter := (rand.Float64()*2 - 1) * _jitterFactor * waitTime //nolint:gosec // we don't need cryptographic randomness
+
+	waitTimeWithJitter := time.Duration(waitTime + jitter)
+
+	select {
+	case <-ctx.Done():
+		return fmt.Errorf("%w", ctx.Err())
+	case <-time.After(waitTimeWithJitter):
+		return nil
+	}
+}
+
+// DefaultIsRetryable defines the default logic to determine if a request should
+// be retried.
+//
+// It returns true if an error occurs or the response status code indicates a
+// retry may be successful (e.g., 202, 408, 429, 502, 503, 504).
+func DefaultIsRetryable(resp *http.Response, err error) bool {
+	if err != nil {
+		return true
+	}
+
+	if resp == nil {
+		return false
+	}
+
+	switch resp.StatusCode {
+	case http.StatusAccepted, // 202
+		http.StatusRequestTimeout,     // 408
+		http.StatusTooManyRequests,    // 429
+		http.StatusBadGateway,         // 502
+		http.StatusServiceUnavailable, // 503
+		http.StatusGatewayTimeout:     // 504
+		return true
+	}
+
+	return false
+}

--- a/internal/xhttp/retry_test.go
+++ b/internal/xhttp/retry_test.go
@@ -92,7 +92,7 @@ func TestRetryPolicy_Wait(t *testing.T) {
 				t.Errorf("Wait() error = %v, expectedErr %v", err, tt.expectedErr)
 			}
 
-			if end.After(expectedEndTime) {
+			if end.Sub(expectedEndTime) > 50*time.Millisecond {
 				t.Errorf("Wait() end time = %v, expectedEndTime %v", end, expectedEndTime)
 			}
 		})

--- a/internal/xhttp/retry_test.go
+++ b/internal/xhttp/retry_test.go
@@ -1,0 +1,193 @@
+package xhttp_test
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/DataDog/cloudcraft-go/internal/xhttp"
+)
+
+func TestRetryPolicy_Wait(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		maxRetries      int
+		minRetryDelay   time.Duration
+		maxRetryDelay   time.Duration
+		attempt         int
+		contextFunc     func() (context.Context, context.CancelFunc)
+		expectedWaitMax time.Duration
+		expectedErr     error
+	}{
+		{
+			name:          "Context canceled",
+			maxRetries:    3,
+			minRetryDelay: 1 * time.Second,
+			maxRetryDelay: 30 * time.Second,
+			attempt:       1,
+			contextFunc: func() (context.Context, context.CancelFunc) {
+				ctx, cancel := context.WithCancel(context.Background())
+
+				cancel() // Cancel the context immediately.
+
+				return ctx, cancel
+			},
+			expectedWaitMax: 1 * time.Millisecond,
+			expectedErr:     context.Canceled,
+		},
+		{
+			name:          "Maximum retry delay exceeded",
+			maxRetries:    3,
+			minRetryDelay: 1 * time.Second,
+			maxRetryDelay: 2 * time.Second,
+			attempt:       4, // This should result in a calculated delay > maxRetryDelay
+			contextFunc: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), 10*time.Second)
+			},
+			expectedWaitMax: 3 * time.Second,
+			expectedErr:     nil,
+		},
+		{
+			name:          "Minimum retry delay",
+			maxRetries:    3,
+			minRetryDelay: 1 * time.Second,
+			maxRetryDelay: 30 * time.Second,
+			attempt:       0, // First attempt
+			contextFunc: func() (context.Context, context.CancelFunc) {
+				return context.WithTimeout(context.Background(), 10*time.Second)
+			},
+			expectedWaitMax: 1 * time.Second,
+			expectedErr:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			policy := xhttp.RetryPolicy{
+				IsRetryable:   xhttp.DefaultIsRetryable,
+				MaxRetries:    tt.maxRetries,
+				MinRetryDelay: tt.minRetryDelay,
+				MaxRetryDelay: tt.maxRetryDelay,
+			}
+
+			ctx, cancel := tt.contextFunc()
+			defer cancel()
+
+			var (
+				start           = time.Now()
+				err             = policy.Wait(ctx, tt.attempt)
+				end             = time.Now()
+				expectedEndTime = start.Add(tt.expectedWaitMax)
+			)
+
+			if !errors.Is(err, tt.expectedErr) {
+				t.Errorf("Wait() error = %v, expectedErr %v", err, tt.expectedErr)
+			}
+
+			if end.After(expectedEndTime) {
+				t.Errorf("Wait() end time = %v, expectedEndTime %v", end, expectedEndTime)
+			}
+		})
+	}
+}
+
+func TestDefaultIsRetryable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		giveResp  *http.Response
+		giveError error
+		want      bool
+	}{
+		{
+			name:      "Error occurs",
+			giveResp:  nil,
+			giveError: errors.New("error"),
+			want:      true,
+		},
+		{
+			name: "Status code 202",
+			giveResp: &http.Response{
+				StatusCode: http.StatusAccepted,
+			},
+			giveError: nil,
+			want:      true,
+		},
+		{
+			name: "Status code 408",
+			giveResp: &http.Response{
+				StatusCode: http.StatusRequestTimeout,
+			},
+			giveError: nil,
+			want:      true,
+		},
+		{
+			name: "Status code 429",
+			giveResp: &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+			},
+			giveError: nil,
+			want:      true,
+		},
+		{
+			name: "Status code 502",
+			giveResp: &http.Response{
+				StatusCode: http.StatusBadGateway,
+			},
+			giveError: nil,
+			want:      true,
+		},
+		{
+			name: "Status code 503",
+			giveResp: &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+			},
+			giveError: nil,
+			want:      true,
+		},
+		{
+			name: "Status code 504",
+			giveResp: &http.Response{
+				StatusCode: http.StatusGatewayTimeout,
+			},
+			giveError: nil,
+			want:      true,
+		},
+		{
+			name: "Status code not triggering retry",
+			giveResp: &http.Response{
+				StatusCode: http.StatusOK,
+			},
+			giveError: nil,
+			want:      false,
+		},
+		{
+			name:      "No error and no response",
+			giveResp:  nil,
+			giveError: nil,
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			want := xhttp.DefaultIsRetryable(tt.giveResp, tt.giveError)
+			if want != tt.want {
+				t.Errorf("DefaultIsRetryable() = %v, want %v", want, tt.want)
+			}
+		})
+	}
+}

--- a/internal/xos/env.go
+++ b/internal/xos/env.go
@@ -6,6 +6,7 @@ package xos
 
 import (
 	"os"
+	"strconv"
 	"time"
 )
 
@@ -20,6 +21,25 @@ func GetEnv(key, fallback string) string {
 	}
 
 	return value
+}
+
+// GetIntEnv returns the integer value of the environment variable named by the
+// key.
+//
+// If the variable is present in the environment the value (which may be empty)
+// or if the variable is unset, a fallback value is returned.
+func GetIntEnv(key string, fallback int) int {
+	value, found := os.LookupEnv(key)
+	if !found || value == "" {
+		return fallback
+	}
+
+	intValue, err := strconv.Atoi(value)
+	if err != nil {
+		return fallback
+	}
+
+	return intValue
 }
 
 // GetDurationEnv returns the time.Duration value of the environment variable

--- a/internal/xos/env_test.go
+++ b/internal/xos/env_test.go
@@ -57,6 +57,51 @@ func TestGetEnv(t *testing.T) {
 	}
 }
 
+func TestGetIntEnv(t *testing.T) {
+	tests := []struct {
+		name     string
+		key      string
+		fallback int
+		envVal   string
+		want     int
+	}{
+		{
+			name:     "non-existent variable with a fallback",
+			key:      "SOMETHING_THAT_DOES_NOT_EXIST",
+			fallback: 123,
+			envVal:   "",
+			want:     123,
+		},
+		{
+			name:     "existent variable with a valid integer value",
+			key:      "SOME_EXISTENT_VARIABLE",
+			fallback: 123,
+			envVal:   "456",
+			want:     456,
+		},
+		{
+			name:     "existent variable with an invalid integer value",
+			key:      "SOME_EXISTENT_VARIABLE",
+			fallback: 123,
+			envVal:   "not-an-integer",
+			want:     123,
+		},
+	}
+
+	for _, tt := range tests { //nolint:paralleltest // Test is not safe to run in parallel.
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(tt.key, tt.envVal)
+			defer os.Unsetenv(tt.key)
+
+			got := xos.GetIntEnv(tt.key, tt.fallback)
+
+			if got != tt.want {
+				t.Errorf("GetIntEnv() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGetDurationEnv(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/xtesting/setup.go
+++ b/internal/xtesting/setup.go
@@ -47,11 +47,12 @@ func SetupLiveClient(t *testing.T) *cloudcraft.Client {
 	key := GetEnv(t, _envAPIKey)
 
 	cfg := &cloudcraft.Config{
-		Scheme: cloudcraft.DefaultScheme,
-		Host:   cloudcraft.DefaultHost,
-		Port:   cloudcraft.DefaultPort,
-		Path:   cloudcraft.DefaultPath,
-		Key:    key,
+		Scheme:     cloudcraft.DefaultScheme,
+		Host:       cloudcraft.DefaultHost,
+		Port:       cloudcraft.DefaultPort,
+		Path:       cloudcraft.DefaultPath,
+		MaxRetries: 8,
+		Key:        key,
 	}
 
 	client, err := cloudcraft.NewClient(cfg)

--- a/tests/integration/retries_test.go
+++ b/tests/integration/retries_test.go
@@ -1,0 +1,80 @@
+package integration_test
+
+import (
+	"context"
+	"strconv"
+	"testing"
+
+	"github.com/DataDog/cloudcraft-go"
+	"github.com/DataDog/cloudcraft-go/internal/xtesting"
+)
+
+func TestRetries(t *testing.T) {
+	t.Parallel()
+
+	var (
+		client = xtesting.SetupLiveClient(t)
+		ctx    = context.Background()
+	)
+
+	give := &cloudcraft.Blueprint{
+		Data: &cloudcraft.BlueprintData{
+			Name: xtesting.UniqueName(t),
+		},
+	}
+
+	blueprint, _, err := client.Blueprint.Create(ctx, give)
+	if err != nil {
+		t.Fatalf("failed to create blueprint: %v", err)
+	}
+
+	if blueprint == nil {
+		t.Fatalf("blueprint is nil")
+	}
+
+	var (
+		blueprintID   = blueprint.ID
+		blueprintName = blueprint.Name
+	)
+
+	for i := 0; i < 10; i++ {
+		iStr := strconv.Itoa(i)
+
+		give = &cloudcraft.Blueprint{
+			ID:   blueprintID,
+			Name: blueprintName + " (" + iStr + ")",
+			Data: &cloudcraft.BlueprintData{
+				Name: blueprintName + " (" + iStr + ")",
+				Nodes: []map[string]any{
+					{
+						"id":           "98172baa-a059-4b04-832d-8a7f5d14b595",
+						"type":         "ec2",
+						"region":       "us-east-1",
+						"platform":     "linux",
+						"instanceType": "m5",
+						"instanceSize": "large",
+					},
+				},
+			},
+		}
+
+		_, err = client.Blueprint.Update(ctx, give, "")
+		if err != nil {
+			t.Fatalf("failed to update blueprint: %v", err)
+		}
+	}
+
+	blueprint, _, err = client.Blueprint.Get(ctx, blueprintID)
+	if err != nil {
+		t.Fatalf("failed to get blueprint: %v", err)
+	}
+
+	if blueprint.Name != give.Name {
+		t.Fatalf("blueprint name not updated; possibly due to error in retry logic: wanted %q, got %q", give.Name, blueprint.Name)
+	}
+
+	_, err = client.Blueprint.Delete(ctx, blueprintID)
+	if err != nil {
+		t.Fatalf("failed to delete blueprint: %v", err)
+	}
+}


### PR DESCRIPTION
### What does this PR do?
Enhance the default HTTP client with retrying features, allowing failed HTTP requests to be retried up to a maximum configurable value. This enhancement should help with rate limiting issues.

The implementation itself is very simple and can be improved in time. In tests against the live API, the feature worked with GET and POST endpoints. I didn't test against PUT and DELETE endpoints, but I see no reason why they should fail.

Tests implemented in `internal/xhttp/retry_test.go` may fail at times due to timing issues, but running them again fixes the issue. I'll work on improving them in time.

### Review checklist

Please check relevant items below:

- [x] The title & description contain a short meaningful summary of work completed.
- [x] Tests have been updated/created and are passing locally.
- [x] I've reviewed the [CONTRIBUTING.md](/CONTRIBUTING.md) file.
