### PR TITLE
Convert dynamic errors to constants

### DIFF
--- a/internal/xhttp/response_test.go
+++ b/internal/xhttp/response_test.go
@@ -6,14 +6,16 @@ package xhttp_test
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"testing"
 
+	"github.com/DataDog/cloudcraft-go/internal/xerrors"
 	"github.com/DataDog/cloudcraft-go/internal/xhttp"
 )
+
+const ErrMockClose xerrors.Error = "mock close error"
 
 type errReader struct{}
 
@@ -30,7 +32,7 @@ func (c *customReadCloser) Read(p []byte) (n int, err error) {
 }
 
 func (*customReadCloser) Close() error {
-	return errors.New("mock close error")
+	return fmt.Errorf("%w", ErrMockClose)
 }
 
 func TestDrainResponseBody(t *testing.T) {
@@ -96,7 +98,7 @@ func TestDrainResponseBody_ErrorClose(t *testing.T) {
 		t.Error("expected error, got nil")
 	}
 
-	want := fmt.Errorf("%w: %w", xhttp.ErrCannotCloseResponse, errors.New("mock close error"))
+	want := fmt.Errorf("%w: %w", xhttp.ErrCannotCloseResponse, ErrMockClose)
 	if err.Error() != want.Error() {
 		t.Errorf("got: %v, want: %v", err, want)
 	}

--- a/internal/xhttp/retry_test.go
+++ b/internal/xhttp/retry_test.go
@@ -7,8 +7,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/cloudcraft-go/internal/xerrors"
 	"github.com/DataDog/cloudcraft-go/internal/xhttp"
 )
+
+const ErrGenericError xerrors.Error = "generic error"
 
 func TestRetryPolicy_Wait(t *testing.T) {
 	t.Parallel()
@@ -111,7 +114,7 @@ func TestDefaultIsRetryable(t *testing.T) {
 		{
 			name:      "Error occurs",
 			giveResp:  nil,
-			giveError: errors.New("error"),
+			giveError: ErrGenericError,
 			want:      true,
 		},
 		{


### PR DESCRIPTION
### What does this PR do?
Convert dynamic errors in tests to constants to fix a linting issue found with the latest `golangci-lint` version.

### Review checklist

Please check relevant items below:

- [x] The title & description contain a short meaningful summary of work completed.
- [x] Tests have been updated/created and are passing locally.
- [x] I've reviewed the [CONTRIBUTING.md](/CONTRIBUTING.md) file.
