### PR TITLE
Add support for the new "GET /team" endpoint

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -37,7 +37,7 @@ jobs:
       - name: 'Setup Go environment'
         uses: 'actions/setup-go@v4'
         with:
-          go-version: '>=1.21.5'
+          go-version: '>=1.21.10'
 
       - name: 'Run govulncheck'
         run: 'make vulnerabilities'

--- a/client.go
+++ b/client.go
@@ -56,6 +56,7 @@ type (
 		Azure     *AzureService
 		AWS       *AWSService
 		Blueprint *BlueprintService
+		Team      *TeamService
 		User      *UserService
 
 		// common specifies a common service shared by all services.
@@ -104,6 +105,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.Azure = (*AzureService)(&client.common)
 	client.AWS = (*AWSService)(&client.common)
 	client.Blueprint = (*BlueprintService)(&client.common)
+	client.Team = (*TeamService)(&client.common)
 	client.User = (*UserService)(&client.common)
 
 	return client, nil

--- a/examples/team/list/main.go
+++ b/examples/team/list/main.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+
+	"github.com/DataDog/cloudcraft-go"
+)
+
+func main() {
+	// Get the API key from the environment.
+	key, ok := os.LookupEnv("CLOUDCRAFT_API_KEY")
+	if !ok {
+		log.Fatal("missing env var: CLOUDCRAFT_API_KEY")
+	}
+
+	// Create new Config to initialize a Client.
+	cfg := cloudcraft.NewConfig(key)
+
+	// Create a new Client instance with the given Config.
+	client, err := cloudcraft.NewClient(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// List all teams in the Cloudcraft account.
+	teams, _, err := client.Team.List(context.Background())
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Print the name of each team.
+	for _, team := range teams {
+		log.Println(team.Name)
+	}
+}

--- a/team.go
+++ b/team.go
@@ -37,7 +37,7 @@ type Members struct {
 	UserID     *string `json:"userId,omitempty"`
 	Name       *string `json:"name,omitempty"`
 	Email      string  `json:"email,omitempty"`
-	MfaEnabled bool    `json:"mfaEnabled,omitempty"`
+	MFAEnabled bool    `json:"mfaEnabled,omitempty"`
 }
 
 // List returns a list of teams.

--- a/team.go
+++ b/team.go
@@ -1,0 +1,79 @@
+package cloudcraft
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// teamPath is the path to the team endpoint of the Cloudcraft API.
+const teamPath string = "team"
+
+// TeamService handles communication with the "/team" endpoint of Cloudcraft's
+// developer API.
+type TeamService service
+
+// Team represents a team in Cloudcraft.
+type Team struct {
+	UpdatedAt           time.Time `json:"updatedAt,omitempty"`
+	CreatedAt           time.Time `json:"createdAt,omitempty"`
+	ID                  string    `json:"id,omitempty"`
+	Name                string    `json:"name,omitempty"`
+	CustomerID          string    `json:"customerId,omitempty"`
+	Role                string    `json:"role,omitempty"`
+	Members             []Members `json:"members,omitempty"`
+	Visible             bool      `json:"visible,omitempty"`
+	CrossOrganizational bool      `json:"crossOrganizational,omitempty"`
+	ExternalSharing     bool      `json:"externalSharing,omitempty"`
+}
+
+// Members represents a list of members in a team.
+type Members struct {
+	ID         string  `json:"id,omitempty"`
+	Role       string  `json:"role,omitempty"`
+	UserID     *string `json:"userId,omitempty"`
+	Name       *string `json:"name,omitempty"`
+	Email      string  `json:"email,omitempty"`
+	MfaEnabled bool    `json:"mfaEnabled,omitempty"`
+}
+
+// List returns a list of teams.
+//
+// [API Reference].
+//
+// [API Reference]: https://docs.datadoghq.com/cloudcraft/api/teams/#list-teams
+func (s *TeamService) List(ctx context.Context) ([]*Team, *Response, error) {
+	if ctx == nil {
+		return nil, nil, ErrNilContext
+	}
+
+	var (
+		baseURL  = s.client.cfg.endpoint.String()
+		endpoint strings.Builder
+	)
+
+	endpoint.Grow(len(baseURL) + len(teamPath))
+
+	endpoint.WriteString(baseURL)
+	endpoint.WriteString(teamPath)
+
+	req, err := s.client.request(ctx, http.MethodGet, endpoint.String(), http.NoBody)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w", err)
+	}
+
+	resp, err := s.client.do(req)
+	if err != nil {
+		return nil, nil, fmt.Errorf("%w", err)
+	}
+
+	var result []*Team
+	if err := json.Unmarshal(resp.Body, &result); err != nil {
+		return nil, resp, fmt.Errorf("%w", err)
+	}
+
+	return result, resp, nil
+}

--- a/team_test.go
+++ b/team_test.go
@@ -1,0 +1,122 @@
+package cloudcraft_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/DataDog/cloudcraft-go"
+	"github.com/DataDog/cloudcraft-go/internal/xtesting"
+)
+
+const _testTeamDataPath string = "tests/data/team"
+
+func TestTeamService_List(t *testing.T) {
+	t.Parallel()
+
+	var (
+		validTestData   = xtesting.ReadFile(t, filepath.Join(_testTeamDataPath, "list-valid.json"))
+		invalidTestData = xtesting.ReadFile(t, filepath.Join(_testTeamDataPath, "list-invalid.json"))
+		ctx             = context.Background()
+	)
+
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+		context context.Context
+		want    []*cloudcraft.Team
+		wantErr bool
+	}{
+		{
+			name: "Valid team data",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+
+				w.Write(validTestData)
+			},
+			context: ctx,
+			want: []*cloudcraft.Team{
+				{
+					ID:                  "2d2f9b4d-53ac-463f-9c7a-97249a22a7fa",
+					Name:                "Team Cloudcraft SDKs",
+					Visible:             true,
+					CrossOrganizational: false,
+					CustomerID:          "e6d4ccd3-551e-425f-b415-637f9005ed2a",
+					UpdatedAt:           xtesting.ParseTime(t, "2022-10-10T17:01:11.214Z"),
+					CreatedAt:           xtesting.ParseTime(t, "2022-10-10T17:01:11.214Z"),
+					ExternalSharing:     true,
+					Role:                "owner",
+					Members: []cloudcraft.Members{
+						{
+							ID:         "aa54884d-5c7b-4586-8139-7a6e39231cc9",
+							Role:       "owner",
+							UserID:     nil,
+							Name:       nil,
+							Email:      "hello@example.com",
+							MFAEnabled: true,
+						},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Invalid team data",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+
+				w.Write(invalidTestData)
+			},
+			context: ctx,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "API error response",
+			handler: func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusInternalServerError)
+			},
+			context: ctx,
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "Nil context",
+			handler: func(_ http.ResponseWriter, _ *http.Request) {},
+			context: nil,
+			want:    nil,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ts := httptest.NewServer(tt.handler)
+			defer ts.Close()
+
+			endpoint, err := url.Parse(ts.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			client := xtesting.SetupMockClient(t, endpoint)
+
+			got, _, err := client.Team.List(tt.context)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("AzureTeam.List() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if !tt.wantErr && !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("AzureTeam.List() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/data/team/list-invalid.json
+++ b/tests/data/team/list-invalid.json
@@ -1,0 +1,11 @@
+[
+  {
+    "id": "2d2f9b4d-53ac-463f-9c7a-97249a22a7fa",
+    "name": "Team Cloudcraft SDKs",
+    "visible": true,
+    "crossOrganizational": false,
+    "customerId": "e6d4ccd3-551e-425f-b415-637f9005ed2a",
+    "updatedAt": "2022-10-10T17:01:11.214Z",
+    "createdAt": "2022-10-10T17:01:11.214Z",
+    "externalSharing": true,
+    "role": "owner",

--- a/tests/data/team/list-valid.json
+++ b/tests/data/team/list-valid.json
@@ -1,0 +1,23 @@
+[
+  {
+    "id": "2d2f9b4d-53ac-463f-9c7a-97249a22a7fa",
+    "name": "Team Cloudcraft SDKs",
+    "visible": true,
+    "crossOrganizational": false,
+    "customerId": "e6d4ccd3-551e-425f-b415-637f9005ed2a",
+    "updatedAt": "2022-10-10T17:01:11.214Z",
+    "createdAt": "2022-10-10T17:01:11.214Z",
+    "externalSharing": true,
+    "role": "owner",
+    "members": [
+      {
+        "id": "aa54884d-5c7b-4586-8139-7a6e39231cc9",
+        "role": "owner",
+        "userId": null,
+        "name": null,
+        "email": "hello@example.com",
+        "mfaEnabled": true
+      }
+    ]
+  }
+]

--- a/tests/integration/team_test.go
+++ b/tests/integration/team_test.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed under the Apache-2.0 License.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-Present Datadog, Inc.
+
+package integration_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DataDog/cloudcraft-go/internal/xtesting"
+)
+
+func TestTeam(t *testing.T) {
+	t.Parallel()
+
+	var (
+		client = xtesting.SetupLiveClient(t)
+		ctx    = context.Background()
+	)
+
+	teams, _, err := client.Team.List(ctx)
+	if err != nil {
+		t.Fatalf("failed to get teams: %v", err)
+	}
+
+	if len(teams) == 0 {
+		t.Fatalf("no teams found")
+	}
+}


### PR DESCRIPTION
### What does this PR do?
Adds support for the [recently documented](https://docs.datadoghq.com/cloudcraft/api/teams/#list-teams) `GET /team` endpoint of the Cloudcraft API.

### Review checklist

Please check relevant items below:

- [x] The title & description contain a short meaningful summary of work completed.
- [x] Tests have been updated/created and are passing locally.
- [x] I've reviewed the [CONTRIBUTING.md](/CONTRIBUTING.md) file.
